### PR TITLE
Update fMRIPrep_Demo_2_RunningAnalysis.rst

### DIFF
--- a/docs/OpenScience/OS/fMRIPrep_Demo_2_RunningAnalysis.rst
+++ b/docs/OpenScience/OS/fMRIPrep_Demo_2_RunningAnalysis.rst
@@ -38,7 +38,7 @@ Which will install all of the programs used by fMRIPrep - for example, tools fro
 Contents of the fMRIPrep Script
 *******************************
 
-To run fMRIPrep, download the code from `this github page <https://github.com/andrewjahn/OpenScience_Scripts/blob/master/fmriprep.sh>`__. Then, navigate to your ``Flanker`` directory and create a new sub-directory by typing ``mkdir code``. We will place the script in this folder to keep our files organized:
+To run fMRIPrep, download the code from `this github page <https://github.com/andrewjahn/OpenScience_Scripts/blob/master/fmriprep_singleSubj.sh>`__. Then, navigate to your ``Flanker`` directory and create a new sub-directory by typing ``mkdir code``. We will place the script in this folder to keep our files organized:
 
 ::
 


### PR DESCRIPTION
Update an outdated URL, 
from: 'https://github.com/andrewjahn/OpenScience_Scripts/blob/master/fmriprep.sh'  to: 'https://github.com/andrewjahn/OpenScience_Scripts/blob/master/fmriprep_singleSubj.sh',  in the section 'Contents of the fMRIPrep Script'.